### PR TITLE
Documentation Typo fixing

### DIFF
--- a/docsrc/content/BioCollections.fsx
+++ b/docsrc/content/BioCollections.fsx
@@ -23,7 +23,7 @@ open FSharpAux
     <a id="APILink" href="https://csbiology.github.io/BioFSharp/reference/biofsharp-bioseq.html" >&#128194;View BioSeq documentation</a>
 </td>
 </table>
-Analogous to the build-in collections BioFSharp provides BioSeq, BioList and BioArray for individual collection specific optimized operations. The easiest way to create them are the ofBioItemString-functions
+Analogous to the built-in collections BioFSharp provides BioSeq, BioList and BioArray for individual collection specific optimized operations. The easiest way to create them are the `ofBioItemString` functions
 *)
 
 
@@ -64,9 +64,9 @@ let myPeptideMass = BioSeq.toAverageMass myPeptide
 (*** include-value:myPeptideMass ***)
 
 (**
-##AminoAcids
+##Amino Acids
 ###Digestion
-BioFSharp also comes equipped with a set of tools aimed at cutting apart amino acid sequences. To demonstrate the usage, we'll throw some `trypsin` at the small RuBisCO subunit of _Arabidopos thaliana_:  
+BioFSharp also comes equipped with a set of tools aimed at cutting apart amino acid sequences. To demonstrate their usage, we'll throw some `trypsin` at the small RuBisCO subunit of _Arabidopos thaliana_:  
 In the first step, we define our input sequence and the protease we want to use.
 *)
 
@@ -79,7 +79,7 @@ let RBCS =
 let trypsin = Digestion.Table.getProteaseBy "Trypsin"
 
 (**
-With these two things done, digesting the protein is a piece of cake. For doing this, just use the `digest` function.  
+With these two things done, digesting the protein is a piece of cake. To do this, just use the `digest` function.  
 *)
 let digestedRBCS = Digestion.BioArray.digest trypsin 0 RBCS 
 
@@ -198,7 +198,7 @@ val digestedRBCS : Digestion.DigestedPeptide [] =
 
 </div>
 <br>
-In reality, proteases don't always completely cut the protein down. Instead, some sites stay intact and should be considered for in silico analysis. This can easily be done with the `concernMissCleavages` function. It takes the minimum and maximum amount of misscleavages you want to have and also the digested protein. As a result you get all possible combinations arising from this information.
+In reality, proteases don't always completely cut the protein down. Instead, some sites stay intact and should be considered for in silico analysis. This can easily be done with the `concernMissCleavages` function. It takes the minimum and maximum amount of misscleavages you want to have and the digested protein. As a result you get all possible combinations arising from this information.
 *)
 let digestedRBCS' = Digestion.BioArray.concernMissCleavages 0 2 digestedRBCS
 
@@ -471,7 +471,7 @@ val digestedRBCS' : Digestion.DigestedPeptide [] =
 </div>
 <br>
 ##Nucleotides
-Let's imagine you have a given gene sequence and want to find out what the according protein might look like.
+Let's imagine you have a given gene sequence and want to find out what the corrisponding protein might look like.
 *)
 let myGene = BioSeq.ofNucleotideString "ATGGCTAGATCGATCGATCGGCTAACGTAA"
 

--- a/docsrc/content/BioItem.fsx
+++ b/docsrc/content/BioItem.fsx
@@ -23,7 +23,7 @@ open BioFSharp.Formula.Table
     <a id="APILink" href="https://csbiology.github.io/BioFSharp/reference/biofsharp-bioitem.html" >&#128194;View module documentation</a>
 </td>
 </table>
-Often, dealing with similar problems separately results in different approaches. In a programming background, this might make things needlessly complex. Therefore in BioFSharp nucleotides and amino acids are based on the same structural scaffold, leading to a consistent way of working with them. This can come in handy especially when working with their formulas.  
+Often, dealing with similar problems separately results in different approaches. In a programming context, this might make things needlessly complex. Therefore in BioFSharp nucleotides and amino acids are based on the same structural scaffold, leading to a consistent way of working with them. This can come in handy, especially when working with their formulas.  
 
 ## Basics
 First let's define some amino acids and nucleotides 
@@ -38,7 +38,7 @@ let t = Nucleotides.T
 let gap = Nucleotides.Gap
 
 (**
-Many functions are similar for AminoAcids and Nucleotides, like for example:
+Many functions are similar for AminoAcids and Nucleotides, for example:
 *)
 (***hide***)
 let alaName = AminoAcids.name ala 
@@ -59,7 +59,7 @@ Nucleotides.formula t |> Formula.toString
 (*** include-value:tFormula ***)
 
 (**
-Nucleotides and AminoAcids in BioFSharp are represented as Union cases. This makes applying functions selectively very easy. 
+Nucleotides and amino acids in BioFSharp are represented as Union cases. This makes applying functions selectively very easy. 
 *)
 let filterLysine aa = 
     match aa with
@@ -131,8 +131,8 @@ giveMePositiveAAs glu
     <a id="APILink" href="https://csbiology.github.io/BioFSharp/reference/biofsharp-modificationinfo.html" >&#128194;View module documentation</a>
 </td>
 </table>
-What makes working on Amino Acids with BioFSharp truly powerful is the ability to easily modify AminoAcids, even altering their mass and formula. In the following example we try to find out the mass of a phosphorylated Serine. Applications like these might be quite usefull for identification of peptides in mass spectrometry.  
-As a first step, we make ourselves an easy helper function which returns the formula of an AminoAcid as string. Afterwards we start out by creating a Serine.
+What makes working on amino acids with BioFSharp truly powerful is the ability to easily modify amino acids, even altering their mass and formula. In the following example we try to find out the mass of a phosphorylated Serine. Applications like these can be useful for peptide identification in mass spectrometry.  
+As a first step, we make ourselves an easy helper function which returns the formula of an amino acid as a string. Afterwards we start out by creating a Serine.
 *)
 
 //easy helper function
@@ -149,7 +149,7 @@ getF mySerine
 (***include-value:getF1***)
 
 (**
-As you can see by the formula. Our Serine is missing two H and an O. In BioFSharp, all Amino Acids are dehydrolysed by default, because it is assumed that the user will use collections representing a peptide, rather than single Amino Acids. For our cause we want serine in hydrolysed form. An easy way to achieve this is to modify it. An addition of H2O is quite common and therefore premade: 
+As you can see by the formula. Our Serine is missing two H's and an O. In BioFSharp, all amino acids are dehydrolysed by default, because it is assumed that the user will use collections representing a peptide, rather than single amino acids. In our case we want Serine in hydrolysed form. An easy way to achieve this is to modify it. An addition of H2O is quite common and therefore premade: 
 *)
 
 ///Hydrolysed serine
@@ -163,7 +163,7 @@ getF hydroSerine
 (***include-value:getF2***)
 
 (**
-So far so good. Now let's add the phosphate. For this we first create a function which alters the formula of a given molecule in the way a phosphorylation would. In the second step we create a modification resembling a phosphorylation of a residual. At last we modify our Serine with this modification.
+So far so good. Now let's add the phosphate. For this we first create a function which alters the formula of a given molecule in the way a phosphorylation would. In the second step we create a modification resembling a phosphorylation of a residual. Finally, we modify our Serine with this modification.
 *)
 
 ///Phosphorylation of OH-Groups adds PO3 to formula and removes one H

--- a/docsrc/content/Formula.fsx
+++ b/docsrc/content/Formula.fsx
@@ -22,7 +22,7 @@
     <a id="APILink" href="https://csbiology.github.io/BioFSharp/reference/biofsharp-formula.html" >&#128194;View module documentation</a>
 </td>
 </table>
-BioFSharp offers a great bunch of functionality for working with molecules. All elements are represented as the composition of their stable isotopes. A `Formula` is a collection of those Elements with the given count. Creating and altering formulas is quite easy. Also functions for obtaining a mass of a molecule, which becomes quite handy especially for mass spectrometry, can be used straightforwardly.  
+BioFSharp offers a variety of functions for working with molecules. All elements are represented as the composition of their stable isotopes. A 'Formula' is a collection of those elements with the given count. Creating and altering formulas is quite easy. Functions for obtaining the mass of a molecule, which is useful for mass spectrometry, are straightforward to use.  
 
 To create formulas, no direct fiddling around with the data type is necessary. You can just use the stringparser:
 *)
@@ -34,7 +34,7 @@ let CO2 = Formula.parseFormulaString "CO2"
 Formula.toString CO2 // val it : string = "C1.00 O2.00 "
 
 (**
-We just created some Carbon Dioxide. Luckily there is no in silico climate change. But let's get rid of it anyways, by making some <a data-toggle="collapse" data-target="#sprudel">Sprudel\*</a>:<div id="sprudel" class="collapse Sprudel">_\*german term for sprinkly water_</div>
+We just created some Carbon Dioxide. Luckily there is no in silico climate change. But let's get rid of it anyways, by making some <a data-toggle="collapse" data-target="#sprudel">Sprudel\*</a>:<div id="sprudel" class="collapse Sprudel">_\*german term for sparkling water_</div>
 *)
 let sprudel = Formula.add CO2 (Formula.Table.H2O)
 Formula.toString sprudel // val it : string = "C1.00 H2.00 O3.00 "

--- a/docsrc/content/Introduction.fsx
+++ b/docsrc/content/Introduction.fsx
@@ -15,7 +15,7 @@ Introduction
 ============
 After you have downloaded and set up BioFSharp (as described [here](index.html#Installation)), it is time to see it in action. Since we are programmers, let's say 'Hello World' !  
 
-The focus of this brief tutorial lies on introducing you to the BioFSharp workflow. We will build a protein from a raw string and look at some of it's properties.
+The focus of this brief tutorial lies on introducing you to the BioFSharp workflow. We will build a protein from a raw string and look at some of its properties.
 Detailed information about the functions used can be either found in the specific tutorials in the sidebar or the API reference. 
 
 First, we reference and open BioFSharp.
@@ -39,9 +39,9 @@ let rawString = "HELLOWORLD!"
 (**
 
 BioFSharp comes with various data structures for biological objects such as amino acids. As you most likely know, you can abbreviate a
-sequence of aminoacids with a three or oneletter code for each single aminoacid. We can convert a character to an aminoacid by using the
-`charToOptionAminoAcid` function from the `BioItemsConverter` library. This will return us an option type, being either an aminoacid or `None` 
-if the caracter is not coding for an aminoacid.
+sequence of amino acids with either a one or three letter code for each amino acid. We can convert a character to an amino acid by using the
+`charToOptionAminoAcid` function from the `BioItemsConverter` library. This will return us an option type, being either an amino acid or `None` 
+if the character does not code for an amino acid.
 
 *)
 
@@ -78,14 +78,14 @@ let parsedProtein3 = rawString |> BioArray.ofAminoAcidString
 (*** include-value:parsedProtein3 ***)
 
 (**
-This yields us our Hello World protein. note that the '!' from the raw string is not contained in the sequence as it is not coding for an aminoacid.
+This yields us our Hello World protein. Note that the '!' from the raw string is not contained in the sequence as it is not coding for an amino acid.
 *)
 
 (**
 Pretty Printing
 ===============
 
-Especially when working with longer sequences or multiple sequences, it can be beneficial to overwrite the default printing of biological datastructures.
+Especially when working with longer sequences or multiple sequences, it can be beneficial to overwrite the default printing of biological data structures.
 BioFSharp comes with a pretty printer for all BioCollections:
 *)
 
@@ -105,7 +105,7 @@ let largerSequence =
 
 (** 
 As you can see here, using the standard printing you are only able to see the first 100 amino acids in this sequence. 
-Now lets take a look on the output when we use the pretty printer:
+Now let's take a look at the output when we use the pretty printer:
 *)
 
 open BioFSharp.IO.FSIPrinters

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -29,7 +29,7 @@ It provides a variety of parsers for many biological file formats and a variety 
 The core datamodel implements in ascending hierarchical order:
 
 - Chemical elements and [formulas](https://csbiology.github.io/BioFSharp/Formula.html) which are a collection of elements
-- Amino Acids], Nucleotides and Modifications, which all implement the common [IBioItem interface](https://csbiology.github.io/BioFSharp/BioItem.html#Basics)
+- [Amino Acids](https://csbiology.github.io/BioFSharp/AminoProperties.html), Nucleotides and Modifications, which all implement the common [IBioItem interface](https://csbiology.github.io/BioFSharp/BioItem.html#Basics)
 - [BioCollections](https://csbiology.github.io/BioFSharp/BioCollections.html) (BioItem,BioList,BioSeq) as representation of biological sequences
 
 </br>
@@ -117,7 +117,7 @@ let arginineMass = AminoAcids.Arg |> AminoAcids.monoisoMass
 
 
 (**
-The various file readers in BioFSharp help to easyly retrieve information and write biology-associated file formats like for example FastA:
+The various file readers in BioFSharp help to easily retrieve information and write biology-associated file formats like FastA:
 *)
 open BioFSharp.IO
 


### PR DESCRIPTION
Partially addresses #32 - general typo and markdown typo fixing

Fixed typos in:

- index.fsk
- Introduction.fsx
- Formula.fsx
- BioItem.fsx
- BioCollections.fsx

