### PR TITLE
fix build target "Nuget"

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -291,6 +291,7 @@ Target.create "RunTests" (fun _ ->
 Target.create "NuGet" (fun _ ->
     Paket.pack(fun p ->
         { p with
+            ToolPath=".paket/paket.exe"
             OutputPath = "bin"
             Version = release.NugetVersion
             ReleaseNotes = String.toLines release.Notes})


### PR DESCRIPTION
fix build target "Nuget"

**Description**
After calling ".paket/paket update" the build target "Nuget" did not find the paket.exe and failed. The paket.exe is now referenced relative to the build.fsx script
