### PR TITLE
improve Sailent.compute characterization speed

### DIFF
--- a/src/BioFSharp.Stats/SurprisalAnalysisEmpiricalPermutationTest.fs
+++ b/src/BioFSharp.Stats/SurprisalAnalysisEmpiricalPermutationTest.fs
@@ -118,7 +118,7 @@ module Sailent =
             groups
             |> Array.map (fun (termName,tmp) ->   
                 let tmp = tmp |> Array.filter (fun ann -> ann.Item > 0.)
-                termName,tmp.Length,tmp |> Array.sumBy (fun x -> abs x.Item))
+                termName,tmp.Length,tmp |> Array.sumBy (fun x -> x.Item))
             |> Array.filter (fun (termName,binSize,weightSum) -> binSize>0)
         
         let negativeTestTargets = 

--- a/src/BioFSharp.Stats/SurprisalAnalysisEmpiricalPermutationTest.fs
+++ b/src/BioFSharp.Stats/SurprisalAnalysisEmpiricalPermutationTest.fs
@@ -125,7 +125,7 @@ module Sailent =
             groups
             |> Array.map (fun (termName,tmp) ->   
                 let tmp = tmp |> Array.filter (fun ann -> ann.Item < 0.)
-                termName,tmp.Length,tmp |> Array.sumBy (fun x -> abs x.Item))
+                termName,tmp.Length,tmp |> Array.sumBy (fun x -> x.Item))
             |> Array.filter (fun (termName,binSize,weightSum) -> binSize>0)
 
         let absoluteBinsizes = absoluteTestTargets |> Array.map (fun (_,binSize,_) -> binSize) |> Array.distinct


### PR DESCRIPTION
Fixes #75

**Description**

Making use of the built in Array.groupBy function had an tremendous speed boost on the characterization step which was the slowest part by far when working with big datasets.

The time improvement can be seen in the following: (QSailent is the updated version)

![SailentSpeedComparison](https://user-images.githubusercontent.com/17880410/75074372-cf51f200-54fb-11ea-90f6-71cd24faef26.png)

Given 1000000 items the old version took 2h now it's down to under 1 second.

**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine
