### PR TITLE
#30 : Add BioSeq tests

### DIFF
--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -237,57 +237,57 @@ let bioCollectionsTests  =
             
             testCase "complement" (fun () ->
                 Expect.equal 
-                    (testCodingStrand |> BioList.ofBioArray |> BioList.complement)
+                    (testCodingStrand |> List.ofArray |> BioList.complement)
                     (testTemplateStrand |> List.ofArray)
                     "BioList.complement did not build the reverse complement of the nucleotide sequence correctly."
             )
 
             testCase "reverseComplement" (fun () ->
                 Expect.equal 
-                    (testCodingStrand |> BioList.ofBioArray |> BioList.reverseComplement)
+                    (testCodingStrand |> List.ofArray |> BioList.reverseComplement)
                     (testCodingStrandRevComplement |> List.ofArray)
                     "BioList.reverseComplement did not build the reverse complement of the nucleotide sequence correctly."
             )
 
             testCase "mapInTriplets" (fun () ->
                 Expect.equal 
-                    (testTemplateStrand |> BioList.ofBioArray |> BioList.mapInTriplets id)
+                    (testTemplateStrand |> List.ofArray |> BioList.mapInTriplets id)
                     (testTriplets |> List.ofArray)
                     "BioList.reverseComplement did not build the correct base triplets."
             )
 
             testCase "transcribeCodeingStrand" (fun () ->
                 Expect.equal 
-                    (testCodingStrand |> BioList.ofBioArray |> BioList.transcribeCodingStrand)
+                    (testCodingStrand |> List.ofArray |> BioList.transcribeCodingStrand)
                     (testTranscript |> List.ofArray)
                     "BioList.transcribeCodeingStrand did not transcribe the coding strand correctly."
             )
 
             testCase "transcribeTemplateStrand" (fun () ->
                 Expect.equal 
-                    (testTemplateStrand |> BioList.ofBioArray |> BioList.transcribeTemplateStrand)
+                    (testTemplateStrand |> List.ofArray |> BioList.transcribeTemplateStrand)
                     (testTranscript |> List.ofArray)
                     "BioList.transcribeTemplateStrand did not transcribe the template strand correctly."
             )
 
             testCase "translate" (fun () ->
                 Expect.equal 
-                    (testTranscript |> BioList.ofBioArray |> BioList.translate 0)
+                    (testTranscript |> List.ofArray |> BioList.translate 0)
                     (testProt |> List.ofArray)
                     "BioList.translate did not translate the transcript correctly."
             )
 
             testCase "isEqual" (fun () ->
                 Expect.equal
-                    (testTranscript |> BioList.ofBioArray
-                    |> BioList.isEqual (testTranscript |> BioList.ofBioArray))
+                    (testTranscript |> List.ofArray
+                    |> BioList.isEqual (testTranscript |> List.ofArray))
                     0
                     "BioList.isEqual did not return correct integer when transcripts were equal."
             )
 
             testCase "toString" (fun () ->
                 Expect.equal
-                    (aminoAcidSetArray |> BioList.ofBioArray |> BioList.toString)
+                    (aminoAcidSetArray |> List.ofArray |> BioList.toString)
                     "ACDEFGHIKLMNOPQRSTUVWYXJZB-*"
                     "BioList.toString did not return the correct string"
             )
@@ -295,7 +295,7 @@ let bioCollectionsTests  =
             testCase "toMonoisotopicMass" (fun () ->
                 Expect.floatClose
                     Accuracy.high
-                    (testProt |> BioList.ofBioArray |> BioList.toMonoisotopicMass)
+                    (testProt |> List.ofArray |> BioList.toMonoisotopicMass)
                     // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
                     (131.04048 + 99.06841 + 113.08406)
                     "BioList.toMonoisotopicMass did not return correct mass"
@@ -304,7 +304,7 @@ let bioCollectionsTests  =
             testCase "toAverageMass" (fun() ->
                 Expect.floatClose
                     Accuracy.medium // High accuracy was not passing test
-                    (testProt |> BioList.ofBioArray |> BioList.toAverageMass)
+                    (testProt |> List.ofArray |> BioList.toAverageMass)
                     // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
                     (131.19606 + 99.13106 + 113.15764)
                     "BioList.toAverageMass did not return correct mass"
@@ -313,7 +313,7 @@ let bioCollectionsTests  =
             testCase "toMonoisotopicMassWith" (fun () ->
                 Expect.floatClose
                     Accuracy.high
-                    (testProt |> BioList.ofBioArray |> BioList.toMonoisotopicMassWith 18.0) // 18 = mass of one water molecule
+                    (testProt |> List.ofArray |> BioList.toMonoisotopicMassWith 18.0) // 18 = mass of one water molecule
                     // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
                     (131.04048 + 99.06841 + 113.08406 + 18.0)
                     "BioList.toMonoisotopicMassWith did not return correct mass"
@@ -322,7 +322,7 @@ let bioCollectionsTests  =
             testCase "toAverageMassWith" (fun () ->
                 Expect.floatClose
                     Accuracy.medium
-                    (testProt |> BioList.ofBioArray |> BioList.toAverageMassWith 18.0) // 18 = mass of one water molecule
+                    (testProt |> List.ofArray |> BioList.toAverageMassWith 18.0) // 18 = mass of one water molecule
                     // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
                     (131.19606 + 99.13106 + 113.15764 + 18.0)
                     "BioList.toAverageMassWith did not return correct mass"
@@ -337,7 +337,7 @@ let bioCollectionsTests  =
                 testCompVec.[valIndex] <- testCompVec.[valIndex] + 1
                 testCompVec.[leuIndex] <- testCompVec.[leuIndex] + 1
                 Expect.equal
-                    (testProt |> BioList.ofBioArray |> BioList.toCompositionVector)
+                    (testProt |> List.ofArray |> BioList.toCompositionVector)
                     testCompVec
                     "BioList.toCompositionVector did not return correct vector"
             )

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -478,5 +478,19 @@ let bioCollectionsTests  =
                         (131.19606 + 99.13106 + 113.15764 + 18.0)
                         "BioSeq.toAverageMassWith did not return correct mass"
                 )
+
+                testCase "toCompositionVector" (fun () ->
+                    let testCompVec = Array.zeroCreate 26
+                    let metIndex = 12 // Value of (int(BioItem.symbol Met)) - 65
+                    let valIndex = 21 // Value of (int(BioItem.symbol Val)) - 65
+                    let leuIndex = 11 // Value of (int(BioItem.symbol Leu)) - 65
+                    testCompVec.[metIndex] <- testCompVec.[metIndex] + 1
+                    testCompVec.[valIndex] <- testCompVec.[valIndex] + 1
+                    testCompVec.[leuIndex] <- testCompVec.[leuIndex] + 1
+                    Expect.equal
+                        (testProt |> Seq.ofArray |> BioSeq.toCompositionVector)
+                        testCompVec
+                        "BioSeq.toCompositionVector did not return correct vector"
+                )
         ]
     ]

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -339,7 +339,7 @@ let bioCollectionsTests  =
                 Expect.equal
                     (testProt |> BioList.ofBioArray |> BioList.toCompositionVector)
                     testCompVec
-                    "BioArray.toCompositionVector did not return correct vector"
+                    "BioList.toCompositionVector did not return correct vector"
             )
         ]
 

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -451,5 +451,14 @@ let bioCollectionsTests  =
                         (131.04048 + 99.06841 + 113.08406)
                         "BioSeq.toMonoisotopicMass did not return correct mass"
                 )
+
+                testCase "toAverageMass" (fun() ->
+                    Expect.floatClose
+                        Accuracy.medium // High accuracy was not passing test
+                        (testProt |> Seq.ofArray |> BioSeq.toAverageMass)
+                        // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
+                        (131.19606 + 99.13106 + 113.15764)
+                        "BioSeq.toAverageMass did not return correct mass"
+                )
         ]
     ]

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -442,5 +442,14 @@ let bioCollectionsTests  =
                         "ACDEFGHIKLMNOPQRSTUVWYXJZB-*"
                         "BioSeq.toString did not return the correct string"
                 )
+
+                testCase "toMonoisotopicMass" (fun () ->
+                    Expect.floatClose
+                        Accuracy.high
+                        (testProt |> Seq.ofArray |> BioSeq.toMonoisotopicMass)
+                        // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
+                        (131.04048 + 99.06841 + 113.08406)
+                        "BioSeq.toMonoisotopicMass did not return correct mass"
+                )
         ]
     ]

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -436,5 +436,11 @@ let bioCollectionsTests  =
                         "BioSeq.isEqual did not return correct integer when transcripts were equal."
                 )
 
+                testCase "toString" (fun () ->
+                    Expect.equal
+                        (aminoAcidSetArray |> Seq.ofArray |> BioSeq.toString)
+                        "ACDEFGHIKLMNOPQRSTUVWYXJZB-*"
+                        "BioSeq.toString did not return the correct string"
+                )
         ]
     ]

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -289,7 +289,16 @@ let bioCollectionsTests  =
                 Expect.equal
                     (aminoAcidSetArray |> BioList.ofBioArray |> BioList.toString)
                     "ACDEFGHIKLMNOPQRSTUVWYXJZB-*"
-                    "BioArray.toString did not return the correct string"
+                    "BioList.toString did not return the correct string"
+            )
+
+            testCase "toMonoisotopicMass" (fun () ->
+                Expect.floatClose
+                    Accuracy.high
+                    (testProt |> BioList.ofBioArray |> BioList.toMonoisotopicMass)
+                    // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
+                    (131.04048 + 99.06841 + 113.08406)
+                    "BioList.toMonoisotopicMass did not return correct mass"
             )
         ]
 

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -469,5 +469,14 @@ let bioCollectionsTests  =
                         (131.04048 + 99.06841 + 113.08406 + 18.0)
                         "BioSeq.toMonoisotopicMassWith did not return correct mass"
                 )
+
+                testCase "toAverageMassWith" (fun () ->
+                    Expect.floatClose
+                        Accuracy.medium
+                        (testProt |> Seq.ofArray |> BioSeq.toAverageMassWith 18.0) // 18 = mass of one water molecule
+                        // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
+                        (131.19606 + 99.13106 + 113.15764 + 18.0)
+                        "BioSeq.toAverageMassWith did not return correct mass"
+                )
         ]
     ]

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -310,6 +310,14 @@ let bioCollectionsTests  =
                     "BioList.toAverageMass did not return correct mass"
             )
 
+            testCase "toMonoisotopicMassWith" (fun () ->
+                Expect.floatClose
+                    Accuracy.high
+                    (testProt |> BioList.ofBioArray |> BioList.toMonoisotopicMassWith 18.0) // 18 = mass of one water molecule
+                    // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
+                    (131.04048 + 99.06841 + 113.08406 + 18.0)
+                    "BioList.toMonoisotopicMassWith did not return correct mass"
+            )
         ]
 
         testList "BioSeq" [

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -328,6 +328,19 @@ let bioCollectionsTests  =
                     "BioList.toAverageMassWith did not return correct mass"
             )
 
+            testCase "toCompositionVector" (fun () ->
+                let testCompVec = Array.zeroCreate 26
+                let metIndex = 12 // Value of (int(BioItem.symbol Met)) - 65
+                let valIndex = 21 // Value of (int(BioItem.symbol Val)) - 65
+                let leuIndex = 11 // Value of (int(BioItem.symbol Leu)) - 65
+                testCompVec.[metIndex] <- testCompVec.[metIndex] + 1
+                testCompVec.[valIndex] <- testCompVec.[valIndex] + 1
+                testCompVec.[leuIndex] <- testCompVec.[leuIndex] + 1
+                Expect.equal
+                    (testProt |> BioList.ofBioArray |> BioList.toCompositionVector)
+                    testCompVec
+                    "BioArray.toCompositionVector did not return correct vector"
+            )
         ]
 
         testList "BioSeq" [

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -284,7 +284,13 @@ let bioCollectionsTests  =
                     0
                     "BioList.isEqual did not return correct integer when transcripts were equal."
             )
-            
+
+            testCase "toString" (fun () ->
+                Expect.equal
+                    (aminoAcidSetArray |> BioList.ofBioArray |> BioList.toString)
+                    "ACDEFGHIKLMNOPQRSTUVWYXJZB-*"
+                    "BioArray.toString did not return the correct string"
+            )
         ]
 
         testList "BioSeq" [

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -277,6 +277,14 @@ let bioCollectionsTests  =
                     "BioList.translate did not translate the transcript correctly."
             )
 
+            testCase "isEqual" (fun () ->
+                Expect.equal
+                    (testTranscript |> BioList.ofBioArray
+                    |> BioList.isEqual (testTranscript |> BioList.ofBioArray))
+                    0
+                    "BioList.isEqual did not return correct integer when transcripts were equal."
+            )
+            
         ]
 
         testList "BioSeq" [

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -300,6 +300,16 @@ let bioCollectionsTests  =
                     (131.04048 + 99.06841 + 113.08406)
                     "BioList.toMonoisotopicMass did not return correct mass"
             )
+
+            testCase "toAverageMass" (fun() ->
+                Expect.floatClose
+                    Accuracy.medium // High accuracy was not passing test
+                    (testProt |> BioList.ofBioArray |> BioList.toAverageMass)
+                    // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
+                    (131.19606 + 99.13106 + 113.15764)
+                    "BioList.toAverageMass did not return correct mass"
+            )
+
         ]
 
         testList "BioSeq" [

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -428,5 +428,13 @@ let bioCollectionsTests  =
                         "BioSeq.translate did not translate the transcript correctly."
                 )
 
+                testCase "isEqual" (fun () ->
+                    Expect.equal
+                        (testTranscript |> Seq.ofArray
+                        |> BioSeq.isEqual (testTranscript |> Seq.ofArray))
+                        0
+                        "BioSeq.isEqual did not return correct integer when transcripts were equal."
+                )
+
         ]
     ]

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -318,6 +318,16 @@ let bioCollectionsTests  =
                     (131.04048 + 99.06841 + 113.08406 + 18.0)
                     "BioList.toMonoisotopicMassWith did not return correct mass"
             )
+
+            testCase "toAverageMassWith" (fun () ->
+                Expect.floatClose
+                    Accuracy.medium
+                    (testProt |> BioList.ofBioArray |> BioList.toAverageMassWith 18.0) // 18 = mass of one water molecule
+                    // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
+                    (131.19606 + 99.13106 + 113.15764 + 18.0)
+                    "BioList.toAverageMassWith did not return correct mass"
+            )
+
         ]
 
         testList "BioSeq" [

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -388,42 +388,42 @@ let bioCollectionsTests  =
             
                 testCase "complement" (fun () ->
                     Expect.sequenceEqual 
-                        (testCodingStrand |> BioSeq.ofBioArray |> BioSeq.complement)
+                        (testCodingStrand |> Seq.ofArray |> BioSeq.complement)
                         (testTemplateStrand |> Seq.ofArray)
                         "BioSeq.complement did not build the reverse complement of the nucleotide sequence correctly."
                 )
 
                 testCase "reverseComplement" (fun () ->
                     Expect.sequenceEqual 
-                        (testCodingStrand |> BioSeq.ofBioArray |> BioSeq.reverseComplement)
+                        (testCodingStrand |> Seq.ofArray |> BioSeq.reverseComplement)
                         (testCodingStrandRevComplement |> Seq.ofArray)
                         "BioSeq.reverseComplement did not build the reverse complement of the nucleotide sequence correctly."
                 )
 
                 testCase "mapInTriplets" (fun () ->
                     Expect.sequenceEqual 
-                        (testTemplateStrand |> BioSeq.ofBioArray |> BioSeq.mapInTriplets id)
+                        (testTemplateStrand |> Seq.ofArray |> BioSeq.mapInTriplets id)
                         (testTriplets |> Seq.ofArray)
                         "BioSeq.reverseComplement did not build the correct base triplets."
                 )
 
                 testCase "transcribeCodeingStrand" (fun () ->
                     Expect.sequenceEqual 
-                        (testCodingStrand |> BioSeq.ofBioArray |> BioSeq.transcribeCodingStrand)
+                        (testCodingStrand |> Seq.ofArray |> BioSeq.transcribeCodingStrand)
                         (testTranscript |> Seq.ofArray)
                         "BioSeq.transcribeCodeingStrand did not transcribe the coding strand correctly."
                 )
 
                 testCase "transcribeTemplateStrand" (fun () ->
                     Expect.sequenceEqual
-                        (testTemplateStrand |> BioSeq.ofBioArray |> BioSeq.transcribeTemplateStrand)
+                        (testTemplateStrand |> Seq.ofArray |> BioSeq.transcribeTemplateStrand)
                         (testTranscript |> Seq.ofArray)
                         "BioSeq.transcribeTemplateStrand did not transcribe the template strand correctly."
                 )
 
                 testCase "translate" (fun () ->
                     Expect.sequenceEqual 
-                        (testTranscript |> BioSeq.ofBioArray |> BioSeq.translate 0)
+                        (testTranscript |> Seq.ofArray |> BioSeq.translate 0)
                         (testProt |> Seq.ofArray)
                         "BioSeq.translate did not translate the transcript correctly."
                 )

--- a/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
+++ b/tests/BioFSharp.Tests.NetCore/BioFSharp/BioCollections.fs
@@ -460,5 +460,14 @@ let bioCollectionsTests  =
                         (131.19606 + 99.13106 + 113.15764)
                         "BioSeq.toAverageMass did not return correct mass"
                 )
+
+                testCase "toMonoisotopicMassWith" (fun () ->
+                    Expect.floatClose
+                        Accuracy.high
+                        (testProt |> Seq.ofArray |> BioSeq.toMonoisotopicMassWith 18.0) // 18 = mass of one water molecule
+                        // Masses obtained from University of Washington Proteomics Resource https://proteomicsresource.washington.edu/protocols06/masses.php
+                        (131.04048 + 99.06841 + 113.08406 + 18.0)
+                        "BioSeq.toMonoisotopicMassWith did not return correct mass"
+                )
         ]
     ]


### PR DESCRIPTION
**Add unit tests to BioSeq testList in BioCollectionsTests module**

**Changes**

Add testCases:
- isEqual
- toString
- toMonoIsotopicMass
- toAverageMass
- toMonoIsotopicMassWith
- toAverageMassWith
- toCompositionVector

to testList BioSeq in BioCollectionsTests module.

Additionally, I changed "BioSeq.ofBioArray" to "Seq.ofArray" on previous unit tests to remove dependence of additional BioSeq functions.


**Description**

This contribution adds seven unit tests for BioSeq in the the BioCollectionsTests module. It also changes six previous unit tests to remove dependency on additional BioSeq functions.

**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

